### PR TITLE
refactor: Update SFTP deployment username in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: deploy file to server
         uses: wlixcc/SFTP-Deploy-Action@v1.2.4
         with:
-          username: 'root'
+          username: 'metrograma'
           server: '${{ secrets.SERVER_IP }}'
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
           local_path: 'www-build'


### PR DESCRIPTION
The code changes in the `.github/workflows/deploy.yml` file update the SFTP deployment username from 'root' to 'metrograma'. This ensures that the correct username is used for the deployment process, improving security and access control.