### PR TITLE
Error prelaciones no sesión

### DIFF
--- a/client/src/hooks/useSubjectGraph.tsx
+++ b/client/src/hooks/useSubjectGraph.tsx
@@ -44,7 +44,8 @@ export default function useSubjectGraph(
 
     const setEnrolledSubjects = getSetEnrolledSubjects(
       enrolledSubjects,
-      errorEnrolledSubjects
+      errorEnrolledSubjects,
+      nodeStatuses
     );
 
     if (!data || !setEnrolledSubjects) return;
@@ -189,10 +190,15 @@ export default function useSubjectGraph(
 
 function getSetEnrolledSubjects(
   enrolledSubjects: string[] | undefined,
-  errorEnrolledSubjects: AxiosError | null
+  errorEnrolledSubjects: AxiosError | null,
+  nodeStatuses: NodeStatuses<Subject>
 ) {
+  // If there is an error fetching the enrolled subjects,
+  // we will use the viewed subjects from the context.
   if (errorEnrolledSubjects) {
-    return new Set<string>();
+    const enrrolledSubjects = new Set<string>(nodeStatuses.viewed.keys());
+
+    return enrrolledSubjects;
   }
 
   return new Set<string>(enrolledSubjects ?? []);

--- a/client/src/layouts/GraphLayout.tsx
+++ b/client/src/layouts/GraphLayout.tsx
@@ -6,7 +6,7 @@ export default function GraphLayout() {
     <>
       <main
         className="bg-gradient-to-b from-primary-900 to-[#1D1B32]
-      text-UI-white w-screen h-screen p-8"
+      text-UI-white h-svh p-8"
       >
         <AuthenticationContext>
           <Outlet />


### PR DESCRIPTION
Cuando el usuario no estaba logueado al calcular las materias que se pueden ver (azules) hacía fetch y daba error resultando en 0 materias vistas a pesar de que en el cliente si esté registrado

Ahora, si el usuario no está logueado y da error su fetch, calcula las materias vistas a partir de los nodos vistos dentro del contexto